### PR TITLE
Align cache image to pixels and add support for device pixel ratio

### DIFF
--- a/src/controllers/ChoroplethController.ts
+++ b/src/controllers/ChoroplethController.ts
@@ -72,6 +72,7 @@ export class ChoroplethController extends GeoController<'choropleth', GeoFeature
       elem.projectionScale = scale;
       elem.feature = (this as any)._data[i].feature;
       elem.center = (this as any)._data[i].center;
+      elem.pixelRatio = this.chart.currentDevicePixelRatio;
       const center = elem.getCenterPoint();
 
       const properties: IGeoFeatureProps & { options?: PointOptions } = {


### PR DESCRIPTION
- Prevent gaps between GeoFeatures by aligning cache images to pixels
- Respect Chart's device pixel ratio to draw geometries in caches

Related to https://github.com/sgratzl/chartjs-chart-geo/issues/31

v3.8.1
<img width="1041" alt="image" src="https://user-images.githubusercontent.com/8651513/183261420-9dd3f5ed-4695-48fa-a527-9f05a78e2f1d.png">

PR with devicePixelRatio = 1
<img width="1041" alt="image" src="https://user-images.githubusercontent.com/8651513/183261427-6d25f9ce-e300-4b90-a81f-5237029e2cec.png">

PR with devicePixelRatio = 2
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/8651513/183261437-c4e74130-ddf6-4bd5-8733-f419a46458d9.png">
