### PR TITLE
Update pixel ratio of outline elements

### DIFF
--- a/samples/albers.html
+++ b/samples/albers.html
@@ -6,8 +6,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       fetch('https://unpkg.com/us-atlas/states-10m.json')

--- a/samples/albersCustom.html
+++ b/samples/albersCustom.html
@@ -6,8 +6,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       fetch('https://unpkg.com/us-atlas/states-10m.json')

--- a/samples/albersLegend.html
+++ b/samples/albersLegend.html
@@ -6,8 +6,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       fetch('https://unpkg.com/us-atlas/states-10m.json')

--- a/samples/albersLog.html
+++ b/samples/albersLog.html
@@ -6,8 +6,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       fetch('https://unpkg.com/us-atlas/states-10m.json')

--- a/samples/albersProjection.html
+++ b/samples/albersProjection.html
@@ -6,8 +6,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       fetch('https://unpkg.com/us-atlas/states-10m.json')

--- a/samples/bubbleMap.html
+++ b/samples/bubbleMap.html
@@ -8,8 +8,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       Chart.register(ChartDataLabels);

--- a/samples/bubbleMapArea.html
+++ b/samples/bubbleMapArea.html
@@ -8,8 +8,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       Promise.all([

--- a/samples/bubbleMapLog.html
+++ b/samples/bubbleMapLog.html
@@ -8,8 +8,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       Promise.all([

--- a/samples/changing.html
+++ b/samples/changing.html
@@ -6,8 +6,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       fetch('https://unpkg.com/us-atlas/states-10m.json')

--- a/samples/earth.html
+++ b/samples/earth.html
@@ -6,8 +6,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       fetch('https://unpkg.com/world-atlas/countries-50m.json')

--- a/samples/earth_click.html
+++ b/samples/earth_click.html
@@ -6,8 +6,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       fetch('https://unpkg.com/world-atlas/countries-50m.json')

--- a/samples/france.html
+++ b/samples/france.html
@@ -8,8 +8,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       fetch('https://raw.githubusercontent.com/rveciana/d3-composite-projections/master/test/data/france.json')

--- a/samples/germany.html
+++ b/samples/germany.html
@@ -6,8 +6,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       const country = fetch(

--- a/samples/worldCenter.html
+++ b/samples/worldCenter.html
@@ -7,8 +7,8 @@
   </head>
 
   <body>
-    <div style="width: 75%">
-      <canvas id="canvas" style="border: 1px solid black"></canvas>
+    <div style="width: 75%; border: 1px solid black">
+      <canvas id="canvas"></canvas>
     </div>
     <script>
       Promise.all([

--- a/src/controllers/GeoController.ts
+++ b/src/controllers/GeoController.ts
@@ -106,6 +106,7 @@ export class GeoController<
         delete elem.cache;
       }
       elem.projectionScale = scale;
+      elem.pixelRatio = this.chart.currentDevicePixelRatio;
       if (mode !== 'resize') {
         const options = patchDatasetElementOptions(this.resolveDatasetElementOptions(mode));
         const properties = {


### PR DESCRIPTION
This is a leftover change of https://github.com/sgratzl/chartjs-chart-geo/pull/126.

- Update pixel ratio of outline elements
- Move the borders to containers in the samples. Borders on canvas distort the aspect ratio a bit and make it hard to see if the contents are crisp enough.

dev with devicePixelRatio = 2
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/8651513/183980191-61b20ccc-2693-468c-9d48-4975f06106fe.png">

PR with devicePixelRatio = 2
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/8651513/183980290-7d20dbed-6aaa-4dcf-bafe-a96edde2fe2f.png">
