### PR TITLE
Use translation from label items options

### DIFF
--- a/src/scales/SizeScale.ts
+++ b/src/scales/SizeScale.ts
@@ -74,7 +74,7 @@ export class SizeScale extends LegendScale<ISizeScaleOptions & LinearScaleOption
     const isHor = this.isHorizontal();
     const values = this.ticks;
     const positions = (this as any)._labelItems
-      ? (this as any)._labelItems.map((el: any) => ({ [isHor ? 'x' : 'y']: el.translation[isHor ? 0 : 1] }))
+      ? (this as any)._labelItems.map((el: any) => ({ [isHor ? 'x' : 'y']: el.options.translation[isHor ? 0 : 1] }))
       : values.map((_, i) => ({ [isHor ? 'x' : 'y']: this.getPixelForTick(i) }));
 
     ((this as any)._gridLineItems || []).forEach((item: any) => {

--- a/src/scales/SizeScale.ts
+++ b/src/scales/SizeScale.ts
@@ -73,8 +73,9 @@ export class SizeScale extends LegendScale<ISizeScaleOptions & LinearScaleOption
 
     const isHor = this.isHorizontal();
     const values = this.ticks;
-    const positions = (this as any)._labelItems
-      ? (this as any)._labelItems.map((el: any) => ({ [isHor ? 'x' : 'y']: el.options.translation[isHor ? 0 : 1] }))
+    const labelItems = this.getLabelItems();
+    const positions = labelItems
+      ? labelItems.map((el: any) => ({ [isHor ? 'x' : 'y']: el.options.translation[isHor ? 0 : 1] }))
       : values.map((_, i) => ({ [isHor ? 'x' : 'y']: this.getPixelForTick(i) }));
 
     ((this as any)._gridLineItems || []).forEach((item: any) => {


### PR DESCRIPTION
Fix #156 
With CHART.JS version 4.1.0, the `_labelitems` are changed to be exposed by the method `getLabelItems` (see https://github.com/chartjs/Chart.js/pull/10966).
the translation array has been moved in `labelitem.options`.